### PR TITLE
Remove report coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - npm run check-coverage
   - npm run build
 after_success:
-  - npm run report-coverage
   - npm run semantic-release
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ﻿[![Travis](https://img.shields.io/travis/UziTech/number-string.svg)](https://travis-ci.org/UziTech/number-string)
-[![Codecov](https://img.shields.io/codecov/c/github/UziTech/number-string.svg)](https://codecov.io/github/UziTech/number-string)
 [![npm downloads](https://img.shields.io/npm/dm/number-string.svg)](https://www.npmjs.com/package/number-string)
 [![npm License](https://img.shields.io/npm/l/number-string.svg)](https://spdx.org/licenses/MIT)
 [![GitHub issues](https://img.shields.io/github/issues/UziTech/number-string.svg)](https://github.com/UziTech/number-string/issues)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "npm run clean && mkdir dist && babel src/app.js -o dist/app.js",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
-    "report-coverage": "cat ./coverage/lcov.info | codecov",
     "clean": "rimraf dist",
     "commit": "npm run clean && git add . && git-cz",
     "push": "git push origin master",


### PR DESCRIPTION
Reporting coverage doesn't work because the coverage is against the dist folder and the dist folder doesn't get committed so codecov.io can't report it